### PR TITLE
fix Surv() in colnames of coxph model fails

### DIFF
--- a/R/mcsimex.R
+++ b/R/mcsimex.R
@@ -178,7 +178,7 @@ mcsimex <- function(model,
       stop("Asymptotic estimation is not supported for coxph models", call. = FALSE)
   if (class(model)[1] == "coxph" && is.null(model$model))
       stop("The option model = TRUE must be enabled for coxph models", call. = FALSE)
-  if (class(model)[1] == "coxph" && grep("Surv\\(", names(model$model)[1]) == 1){
+  if (class(model)[1] == "coxph" && length(grep("Surv\\(", names(model$model)[1])) > 0){
       timeEventMatrix <- as.matrix(model$model[[1]])
       timeName <- sub("Surv\\(","",strsplit(names(model$model)[1], ", ")[[1]][1])
       eventName <- sub("\\)","",strsplit(names(model$model)[1], ", ")[[1]][2])

--- a/R/simex.R
+++ b/R/simex.R
@@ -226,7 +226,7 @@ simex <-
         stop("Asymptotic estimation is not supported for coxph models", call. = FALSE)
     if (class(model)[1] == "coxph" && is.null(model$model))
         stop("The option model = TRUE must be enabled for coxph models", call. = FALSE)
-    if (class(model)[1] == "coxph" && grep("Surv\\(", names(model$model)[1]) == 1){
+    if (class(model)[1] == "coxph" && length(grep("Surv\\(", names(model$model)[1])) > 0){
         timeEventMatrix <- as.matrix(model$model[[1]])
         timeName <- sub("Surv\\(","",strsplit(names(model$model)[1], ", ")[[1]][1])
         eventName <- sub("\\)","",strsplit(names(model$model)[1], ", ")[[1]][2])


### PR DESCRIPTION
Check to see if the outcome in the coxph model object was created with Surv() in the coxph formula, and thus needed adjustment, failed, since grep returns an empty integer rather than zero, when there is no match.